### PR TITLE
Added missing word

### DIFF
--- a/src/cio_io_vector.h
+++ b/src/cio_io_vector.h
@@ -9,7 +9,7 @@ extern "C" {
 
 /**
  * \file
- * @brief This file contains the of a scatter/gather I/O buffer element.
+ * @brief This file contains the structure of a scatter/gather I/O buffer element.
  */
 
 /**


### PR DESCRIPTION
Even though this is a minor slip, but does the sentence: 

This file contains the structure of a scatter/gather I/O buffer element.

meet your original intent?