### PR TITLE
Fix event notification of removed events.

### DIFF
--- a/src/linux/cio_linux_epoll.h
+++ b/src/linux/cio_linux_epoll.h
@@ -85,6 +85,7 @@ struct cio_linux_eventloop_epoll {
 	int epoll_fd;
 	bool go_ahead;
 	unsigned int event_counter;
+	unsigned int num_events;
 	struct epoll_event epoll_events[CONFIG_MAX_EPOLL_EVENTS];
 };
 
@@ -92,7 +93,7 @@ enum cio_error cio_linux_eventloop_init(struct cio_linux_eventloop_epoll *loop);
 void cio_linux_eventloop_destroy(const struct cio_linux_eventloop_epoll *loop);
 
 enum cio_error cio_linux_eventloop_add(const struct cio_linux_eventloop_epoll *loop, struct cio_linux_event_notifier *ev);
-void cio_linux_eventloop_remove(const struct cio_linux_eventloop_epoll *loop, struct cio_linux_event_notifier *ev);
+void cio_linux_eventloop_remove(struct cio_linux_eventloop_epoll *loop, struct cio_linux_event_notifier *ev);
 enum cio_error cio_linux_eventloop_run(struct cio_linux_eventloop_epoll *loop);
 void cio_linux_eventloop_cancel(struct cio_linux_eventloop_epoll *loop);
 

--- a/src/linux/tests/test_cio_linux_server_socket.c
+++ b/src/linux/tests/test_cio_linux_server_socket.c
@@ -43,7 +43,7 @@ void accept_handler(struct cio_server_socket *ss, void *handler_context, enum ci
 FAKE_VOID_FUNC(accept_handler, struct cio_server_socket *, void *, enum cio_error, struct cio_socket *)
 
 FAKE_VALUE_FUNC(enum cio_error, cio_linux_eventloop_add, const struct cio_linux_eventloop_epoll *, struct cio_linux_event_notifier *)
-FAKE_VOID_FUNC(cio_linux_eventloop_remove, const struct cio_linux_eventloop_epoll *, struct cio_linux_event_notifier *)
+FAKE_VOID_FUNC(cio_linux_eventloop_remove, struct cio_linux_eventloop_epoll *, struct cio_linux_event_notifier *)
 
 void on_close(struct cio_linux_server_socket *ss);
 FAKE_VOID_FUNC(on_close, struct cio_linux_server_socket *)


### PR DESCRIPTION
If more than on event is ready after epoll_wait, it must be ensured that
ready-fds are not signaled anymore if they were removed by a previous
event callback.

Consider the following situation. You have a socket fd and a timer fd
which is used to check if communication is done in time. Now, both fds
get ready after epoll_wait. In the callback of the socket fd the timer
will be cancelled. Now the timer fd must not be used any longer.