### PR TITLE
Build tests with std=gnu99.

### DIFF
--- a/src/linux/tests/CMakeLists.txt
+++ b/src/linux/tests/CMakeLists.txt
@@ -15,6 +15,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../fff/)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../unity/src/)
 
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+
 add_executable(test_cio_linux_epoll
     test_cio_linux_epoll.c
     ../cio_linux_epoll.c

--- a/src/linux/tests/test_cio_linux_server_socket.c
+++ b/src/linux/tests/test_cio_linux_server_socket.c
@@ -109,10 +109,10 @@ static int listen_fails(int sockfd, int backlog)
 	return -1;
 }
 
-static int setsockopt_fails(int socket, int level, int option_name,
+static int setsockopt_fails(int fd, int level, int option_name,
                             const void *option_value, socklen_t option_len)
 {
-	(void)socket;
+	(void)fd;
 	(void)level;
 	(void)option_name;
 	(void)option_value;
@@ -171,11 +171,11 @@ static int accept_fails(int fd, struct sockaddr *addr, socklen_t *addrlen)
 	return -1;
 }
 
-static void accept_handler_close_server_socket(struct cio_server_socket *ss, void *handler_context, enum cio_error err, struct cio_socket *socket)
+static void accept_handler_close_server_socket(struct cio_server_socket *ss, void *handler_context, enum cio_error err, struct cio_socket *sock)
 {
 	(void)handler_context;
 	(void)err;
-	(void)socket;
+	(void)sock;
 	ss->close(ss);
 }
 


### PR DESCRIPTION
Using fff requires C99, but C99 it not useable because calls like
getaddrinfo() are not available then.