### PR TITLE
Feature/socket create

### DIFF
--- a/src/cio_server_socket.h
+++ b/src/cio_server_socket.h
@@ -115,7 +115,8 @@ struct cio_server_socket {
 	 * @brief Binds the cio_server_socket to a specific address
 	 *
 	 * @param context The cio_server_socket::context.
-	 * @param bind_address The IP address a cio_server_socket shall bound to.
+	 * @param bind_address The IP address a cio_server_socket shall bound to. If @p NULL,
+	 *        then cio_server_socket binds to all interfaces.
 	 * @param port The TCP port the cio_server_socket shall listen on.
 	 *
 	 * @return ::cio_success for success.

--- a/src/cio_server_socket.h
+++ b/src/cio_server_socket.h
@@ -161,8 +161,8 @@ struct cio_server_socket {
  * @return ::cio_success for success.
  */
 enum cio_error cio_server_socket_init(struct cio_server_socket *ss,
-                            struct cio_eventloop *loop,
-                            cio_server_socket_close_hook close);
+                                      struct cio_eventloop *loop,
+                                      cio_server_socket_close_hook close);
 
 #ifdef __cplusplus
 }

--- a/src/cio_server_socket.h
+++ b/src/cio_server_socket.h
@@ -81,13 +81,10 @@ struct cio_server_socket {
 	 * @anchor cio_server_socket_init
 	 * @brief Initializes a cio_server_socket.
 	 *
-	 * If this function succeeds, the server socket is bound an listens on the
-	 * port specified. If later on something goes wrong, it's the responsibility
-	 * of the user to call @ref cio_server_socket_close "close" on the server socket.
+	 * If this function succeeds, a server socket is created.
 	 *
 	 * @param context The cio_server_socket::context.
 	 * @param backlog The minimal length of the listen queue.
-	 * If @a bind_address is @p NULL, cio_server_socket will bind to any interface.
 	 *
 	 * @return ::cio_success for success.
 	 */

--- a/src/cio_socket.h
+++ b/src/cio_socket.h
@@ -63,6 +63,18 @@ struct cio_socket {
 	void *context;
 
 	/**
+	 * @anchor cio_socket_init
+	 * @brief Initializes a cio_socket.
+	 *
+	 * Creates an unconnected socket.
+	 *
+	 * @param context The cio_socket::context.
+	 *
+	 * @return ::cio_success for success.
+	 */
+	enum cio_error (*init)(void *context);
+
+	/**
 	 * @anchor cio_socket_get_io_stream
 	 * @brief Gets an I/O stream from the socket.
 	 *
@@ -120,6 +132,10 @@ struct cio_socket {
 	struct cio_event_notifier ev;
 	struct cio_eventloop *loop;
 };
+
+enum cio_error cio_socket_init(struct cio_socket *s,
+                               struct cio_eventloop *loop,
+                               cio_socket_close_hook close_hook);
 
 #ifdef __cplusplus
 }

--- a/src/cio_socket.h
+++ b/src/cio_socket.h
@@ -78,7 +78,7 @@ struct cio_socket {
 	 * @anchor cio_socket_get_io_stream
 	 * @brief Gets an I/O stream from the socket.
 	 *
-	 * @param context The cio_server_socket::context.
+	 * @param context The cio_socket::context.
 	 *
 	 * @return An I/O stream for reading from and writing to this socket.
 	 */
@@ -91,7 +91,7 @@ struct cio_socket {
 	 * Once a socket has been closed, no further communication is possible. Closing the socket
 	 * also closes the socket's cio_io_stream.
 	 *
-	 * @param context The cio_server_socket::context.
+	 * @param context The cio_socket::context.
 	 */
 	void (*close)(void *context);
 
@@ -99,7 +99,7 @@ struct cio_socket {
 	 * @anchor cio_socket_set_tcp_no_delay
 	 * @brief Enables/disables the Nagle algorithm
 	 *
-	 * @param context The cio_server_socket::context.
+	 * @param context The cio_socket::context.
 	 * @param on Whether Nagle algorithm should be enabled or not.
 	 *
 	 * @return ::cio_success for success.
@@ -110,7 +110,7 @@ struct cio_socket {
 	 * @anchor cio_socket_set_keep_alive
 	 * @brief Enables/disables TCP keepalive messages.
 	 *
-	 * @param context The cio_server_socket::context.
+	 * @param context The cio_socket::context.
 	 * @param on Whether or not to enable TCP keepalives.
 	 * @param keep_idle_s Time in seconds the connections needs to remain idle
 	 *        before start sending keepalive messages. This option might be unused

--- a/src/linux/cio_linux_server_socket.c
+++ b/src/linux/cio_linux_server_socket.c
@@ -104,7 +104,7 @@ static void accept_callback(void *context)
 		} else {
 			struct cio_socket *s = cio_malloc(sizeof(*s));
 			if (likely(s != NULL)) {
-				enum cio_error err = cio_socket_init(s, client_fd, ss->loop, free_linux_socket);
+				enum cio_error err = cio_linux_socket_init(s, client_fd, ss->loop, free_linux_socket);
 				ss->handler(ss, ss->handler_context, err, s);
 			} else {
 				close(client_fd);
@@ -209,8 +209,8 @@ static enum cio_error socket_bind(void *context, const char *bind_address, uint1
 }
 
 enum cio_error cio_server_socket_init(struct cio_server_socket *ss,
-                            struct cio_eventloop *loop,
-                            cio_server_socket_close_hook hook)
+                                      struct cio_eventloop *loop,
+                                      cio_server_socket_close_hook hook)
 {
 	ss->context = ss;
 	ss->init = socket_init;

--- a/src/linux/cio_linux_server_socket.c
+++ b/src/linux/cio_linux_server_socket.c
@@ -96,8 +96,12 @@ static void accept_callback(void *context)
 			struct cio_socket *s = cio_malloc(sizeof(*s));
 			if (likely(s != NULL)) {
 				enum cio_error err = cio_linux_socket_init(s, client_fd, ss->loop, free_linux_socket);
-				s->init(s);
-				ss->handler(ss, ss->handler_context, err, s);
+				if (likely(err == cio_success)) {
+					s->init(s);
+					ss->handler(ss, ss->handler_context, err, s);
+				} else {
+					close(client_fd);
+				}
 			} else {
 				close(client_fd);
 			}

--- a/src/linux/cio_linux_server_socket.c
+++ b/src/linux/cio_linux_server_socket.c
@@ -96,6 +96,7 @@ static void accept_callback(void *context)
 			struct cio_socket *s = cio_malloc(sizeof(*s));
 			if (likely(s != NULL)) {
 				enum cio_error err = cio_linux_socket_init(s, client_fd, ss->loop, free_linux_socket);
+				s->init(s);
 				ss->handler(ss, ss->handler_context, err, s);
 			} else {
 				close(client_fd);

--- a/src/linux/cio_linux_server_socket.c
+++ b/src/linux/cio_linux_server_socket.c
@@ -31,8 +31,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 #include "cio_compiler.h"
@@ -46,18 +44,11 @@
 
 static enum cio_error socket_init(void *context, unsigned int backlog)
 {
-	enum cio_error err;
 	struct cio_server_socket *ss = context;
 
-	int listen_fd = socket(AF_INET6, SOCK_STREAM, 0);
+	int listen_fd = cio_linux_socket_create(-1);
 	if (listen_fd == -1) {
 		return (enum cio_error)errno;
-	}
-
-	err = set_fd_non_blocking(listen_fd);
-	if (likely(err != cio_success)) {
-		close(listen_fd);
-		return err;
 	}
 
 	ss->backlog = (int)backlog;

--- a/src/linux/cio_linux_socket.c
+++ b/src/linux/cio_linux_socket.c
@@ -176,9 +176,9 @@ static void loop_callback(void *context)
 	(void)ls;
 }
 
-enum cio_error cio_socket_init(struct cio_socket *s, int client_fd,
-                               struct cio_eventloop *loop,
-                               cio_socket_close_hook close_hook)
+enum cio_error cio_linux_socket_init(struct cio_socket *s, int client_fd,
+                                     struct cio_eventloop *loop,
+                                     cio_socket_close_hook close_hook)
 {
 	enum cio_error err = set_fd_non_blocking(client_fd);
 	if (unlikely(err != cio_success)) {

--- a/src/linux/cio_linux_socket.h
+++ b/src/linux/cio_linux_socket.h
@@ -35,9 +35,9 @@
 extern "C" {
 #endif
 
-enum cio_error cio_socket_init(struct cio_socket *s, int client_fd,
-                               struct cio_eventloop *loop,
-                               cio_socket_close_hook close_hook);
+enum cio_error cio_linux_socket_init(struct cio_socket *s, int client_fd,
+                                     struct cio_eventloop *loop,
+                                     cio_socket_close_hook close_hook);
 
 #ifdef __cplusplus
 }

--- a/src/linux/cio_linux_socket_utils.c
+++ b/src/linux/cio_linux_socket_utils.c
@@ -26,6 +26,8 @@
 
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 
 #include "cio_compiler.h"
 #include "cio_error_code.h"
@@ -44,4 +46,24 @@ enum cio_error set_fd_non_blocking(int fd)
 	}
 
 	return cio_success;
+}
+
+int cio_linux_socket_create(int fd)
+{
+	enum cio_error err;
+
+	if (fd == -1) {
+		fd = socket(AF_INET6, SOCK_STREAM, 0);
+		if (fd == -1) {
+			return -1;
+		}
+	}
+
+	err = set_fd_non_blocking(fd);
+	if (likely(err != cio_success)) {
+		close(fd);
+		return -1;
+	}
+
+	return fd;
 }

--- a/src/linux/cio_linux_socket_utils.c
+++ b/src/linux/cio_linux_socket_utils.c
@@ -33,24 +33,24 @@
 #include "cio_error_code.h"
 #include "linux/cio_linux_socket_utils.h"
 
-enum cio_error set_fd_non_blocking(int fd)
+static int set_fd_non_blocking(int fd)
 {
 	int fd_flags = fcntl(fd, F_GETFL, 0);
 	if (unlikely(fd_flags < 0)) {
-		return (enum cio_error)errno;
+		return -1;
 	}
 
 	fd_flags |= O_NONBLOCK;
 	if (unlikely(fcntl(fd, F_SETFL, fd_flags) < 0)) {
-		return (enum cio_error)errno;
+		return -1;
 	}
 
-	return cio_success;
+	return 0;
 }
 
 int cio_linux_socket_create(int fd)
 {
-	enum cio_error err;
+	int ret;
 
 	if (fd == -1) {
 		fd = socket(AF_INET6, SOCK_STREAM, 0);
@@ -59,8 +59,8 @@ int cio_linux_socket_create(int fd)
 		}
 	}
 
-	err = set_fd_non_blocking(fd);
-	if (likely(err != cio_success)) {
+	ret = set_fd_non_blocking(fd);
+	if (unlikely(ret == -1)) {
 		close(fd);
 		return -1;
 	}

--- a/src/linux/cio_linux_socket_utils.c
+++ b/src/linux/cio_linux_socket_utils.c
@@ -25,9 +25,9 @@
  */
 
 #include <fcntl.h>
-#include <unistd.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #include "cio_compiler.h"
 #include "cio_error_code.h"

--- a/src/linux/cio_linux_socket_utils.h
+++ b/src/linux/cio_linux_socket_utils.h
@@ -33,7 +33,6 @@
 extern "C" {
 #endif
 
-enum cio_error set_fd_non_blocking(int fd);
 int cio_linux_socket_create(int fd);
 
 #ifdef __cplusplus

--- a/src/linux/cio_linux_socket_utils.h
+++ b/src/linux/cio_linux_socket_utils.h
@@ -34,6 +34,7 @@ extern "C" {
 #endif
 
 enum cio_error set_fd_non_blocking(int fd);
+int cio_linux_socket_create(int fd);
 
 #ifdef __cplusplus
 }

--- a/src/linux/tests/CMakeLists.txt
+++ b/src/linux/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(test_cio_linux_server_socket
     test_cio_linux_server_socket.c
     ../cio_linux_server_socket.c
     ../cio_linux_socket.c
+    ../cio_linux_socket_utils.c
 )
 target_link_libraries (test_cio_linux_server_socket unity)
 

--- a/src/linux/tests/test_cio_linux_server_socket.c
+++ b/src/linux/tests/test_cio_linux_server_socket.c
@@ -59,8 +59,6 @@ FAKE_VALUE_FUNC(int, setsockopt, int, int, int, const void *, socklen_t)
 FAKE_VALUE_FUNC(int, bind, int, const struct sockaddr *, socklen_t)
 FAKE_VALUE_FUNC(int, listen, int, int)
 FAKE_VALUE_FUNC(int, close, int)
-enum cio_error set_fd_non_blocking(int);
-FAKE_VALUE_FUNC(enum cio_error, set_fd_non_blocking, int)
 
 FAKE_VALUE_FUNC(void *, cio_malloc, size_t)
 FAKE_VOID_FUNC(cio_free, void *)
@@ -86,7 +84,6 @@ void setUp(void)
 	RESET_FAKE(bind);
 	RESET_FAKE(listen);
 	RESET_FAKE(close);
-	RESET_FAKE(set_fd_non_blocking);
 	RESET_FAKE(cio_malloc);
 	RESET_FAKE(cio_free);
 }
@@ -274,19 +271,6 @@ static void test_accept_fails(void)
 	TEST_ASSERT_EQUAL(&ss, on_close_fake.arg0_val);
 }
 
-static void test_set_nonblocking_fails(void)
-{
-	set_fd_non_blocking_fake.return_val = cio_bad_file_descriptor;
-
-	struct cio_eventloop loop;
-	struct cio_server_socket ss;
-	cio_server_socket_init(&ss, &loop, on_close);
-	enum cio_error err = ss.init(ss.context, 5);
-
-	TEST_ASSERT_EQUAL(cio_bad_file_descriptor, err);
-	TEST_ASSERT_EQUAL(1, close_fake.call_count);
-}
-
 static void test_accept_no_handler(void)
 {
 	struct cio_eventloop loop;
@@ -462,7 +446,6 @@ int main(void)
 	RUN_TEST(test_init_listen_fails);
 	RUN_TEST(test_init_setsockopt_fails);
 	RUN_TEST(test_init_bind_fails);
-	RUN_TEST(test_set_nonblocking_fails);
 	RUN_TEST(test_accept_malloc_fails);
 	RUN_TEST(test_enable_reuse_address);
 	RUN_TEST(test_disable_reuse_address);

--- a/src/linux/tests/tests.qbs
+++ b/src/linux/tests/tests.qbs
@@ -64,6 +64,7 @@ Project {
     files: [
       "test_cio_linux_server_socket.c",
       "../cio_linux_server_socket.c",
+      "../cio_linux_socket_utils.c",
       "../cio_linux_socket.c",
     ]
   }


### PR DESCRIPTION
This patch set mainly provides the functionality to create a socket.
First of all, this is necessary to create unit tests more easily (without the need to create a server socket).

In addition, this is also a prerequisite to later on provide the connect functionality for the sockets.

Some documentation issues were also fixed, and some code was made private.