### PR TITLE
Add a flag that a frame is currently written.

### DIFF
--- a/src/cio_websocket.h
+++ b/src/cio_websocket.h
@@ -195,6 +195,7 @@ struct cio_websocket {
 		unsigned int is_fragmented : 1;
 		unsigned int self_initiated_close : 1;
 		unsigned int is_server : 1;
+		unsigned int writing_frame : 1;
 	} ws_flags;
 
 	void (*receive_frames)(struct cio_websocket *ws);


### PR DESCRIPTION
This flag is used that a new write job will not be accepted while
an existing write job currently running.