### PR TITLE
Use correct data type for websocket length.

### DIFF
--- a/examples/websocket_server.c
+++ b/examples/websocket_server.c
@@ -130,7 +130,7 @@ static void write_complete(struct cio_websocket *ws, void *handler_context, enum
 	}
 }
 
-static void print_payload(const uint8_t *data, size_t length)
+static void print_payload(const uint8_t *data, uint_fast8_t length)
 {
 	if (length > 0) {
 		fwrite(data, length, 1, stdout);
@@ -141,7 +141,7 @@ static void print_payload(const uint8_t *data, size_t length)
 	}
 }
 
-static void on_control(const struct cio_websocket *ws, enum cio_websocket_frame_type type, const uint8_t *data, size_t length)
+static void on_control(const struct cio_websocket *ws, enum cio_websocket_frame_type type, const uint8_t *data, uint_fast8_t length)
 {
 	(void)ws;
 

--- a/src/cio_websocket.c
+++ b/src/cio_websocket.c
@@ -470,7 +470,7 @@ static void handle_pong_frame(struct cio_websocket *ws, uint8_t *data, uint_fast
 static void handle_frame(struct cio_websocket *ws, uint8_t *data, uint64_t length)
 {
 	if (ws->ws_private.ws_flags.is_server == 1) {
-		cio_websocket_mask(data, length, ws->ws_private.received_mask);
+		cio_websocket_mask(data, (size_t)length, ws->ws_private.received_mask);
 	}
 
 	switch (ws->ws_private.ws_flags.opcode) {

--- a/src/cio_websocket.h
+++ b/src/cio_websocket.h
@@ -208,7 +208,7 @@ struct cio_websocket {
 	 * @param data The data the control frame carried.
 	 * @param length The length of data the control frame carried.
 	 */
-	void (*on_control)(const struct cio_websocket *ws, enum cio_websocket_frame_type kind, const uint8_t *data, size_t length);
+	void (*on_control)(const struct cio_websocket *ws, enum cio_websocket_frame_type kind, const uint8_t *data, uint_fast8_t length);
 
 	/**
 	 * @brief A pointer to a function which is called if a receive error occurred.

--- a/src/cio_websocket_masking.h
+++ b/src/cio_websocket_masking.h
@@ -35,7 +35,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
-static inline void cio_websocket_mask(uint8_t *buffer, uint64_t length, const uint8_t mask[4])
+static inline void cio_websocket_mask(uint8_t *buffer, size_t length, const uint8_t mask[4])
 {
 	uint_fast32_t aligned_mask;
 	static_assert(sizeof(aligned_mask) % 4 == 0, "This algorithm works only if the mask is a multiple of 4 bytes!");
@@ -51,7 +51,7 @@ static inline void cio_websocket_mask(uint8_t *buffer, uint64_t length, const ui
 	unsigned int pre_length = ((uintptr_t)buffer) % sizeof(aligned_mask);
 	pre_length = (sizeof(aligned_mask) - pre_length) % sizeof(aligned_mask);
 
-	uint64_t main_length = (length - pre_length) / sizeof(aligned_mask);
+	size_t main_length = (length - pre_length) / sizeof(aligned_mask);
 	unsigned int post_length = (unsigned int)(length - pre_length - (main_length * sizeof(aligned_mask)));
 
 	uint_fast32_t *buffer_aligned = (void *)(buffer + pre_length);
@@ -72,7 +72,7 @@ static inline void cio_websocket_mask(uint8_t *buffer, uint64_t length, const ui
 		buffer_aligned++;
 	}
 
-	for (uint64_t i = length - post_length; i < length; i++) {
+	for (size_t i = length - post_length; i < length; i++) {
 		buffer[i] ^= (mask[i % 4]);
 	}
 }

--- a/src/cio_websocket_masking.h
+++ b/src/cio_websocket_masking.h
@@ -35,7 +35,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
-static inline void cio_websocket_mask(uint8_t *buffer, size_t length, const uint8_t mask[4])
+static inline void cio_websocket_mask(uint8_t *buffer, uint64_t length, const uint8_t mask[4])
 {
 	uint_fast32_t aligned_mask;
 	static_assert(sizeof(aligned_mask) % 4 == 0, "This algorithm works only if the mask is a multiple of 4 bytes!");
@@ -51,7 +51,7 @@ static inline void cio_websocket_mask(uint8_t *buffer, size_t length, const uint
 	unsigned int pre_length = ((uintptr_t)buffer) % sizeof(aligned_mask);
 	pre_length = (sizeof(aligned_mask) - pre_length) % sizeof(aligned_mask);
 
-	size_t main_length = (length - pre_length) / sizeof(aligned_mask);
+	uint64_t main_length = (length - pre_length) / sizeof(aligned_mask);
 	unsigned int post_length = (unsigned int)(length - pre_length - (main_length * sizeof(aligned_mask)));
 
 	uint_fast32_t *buffer_aligned = (void *)(buffer + pre_length);
@@ -72,7 +72,7 @@ static inline void cio_websocket_mask(uint8_t *buffer, size_t length, const uint
 		buffer_aligned++;
 	}
 
-	for (size_t i = length - post_length; i < length; i++) {
+	for (uint64_t i = length - post_length; i < length; i++) {
 		buffer[i] ^= (mask[i % 4]);
 	}
 }

--- a/src/tests/test_cio_websocket.c
+++ b/src/tests/test_cio_websocket.c
@@ -77,8 +77,8 @@ FAKE_VALUE_FUNC(enum cio_error, bs_write, struct cio_buffered_stream *, struct c
 static void on_connect(struct cio_websocket *s);
 FAKE_VOID_FUNC(on_connect, struct cio_websocket *)
 
-static void on_control(const struct cio_websocket *ws, enum cio_websocket_frame_type type, const uint8_t *data, size_t length);
-FAKE_VOID_FUNC(on_control, const struct cio_websocket *, enum cio_websocket_frame_type, const uint8_t *, size_t)
+static void on_control(const struct cio_websocket *ws, enum cio_websocket_frame_type type, const uint8_t *data, uint_fast8_t length);
+FAKE_VOID_FUNC(on_control, const struct cio_websocket *, enum cio_websocket_frame_type, const uint8_t *, uint_fast8_t)
 
 static void on_error(const struct cio_websocket *ws, enum cio_websocket_status_code status, const char *reason);
 FAKE_VOID_FUNC(on_error, const struct cio_websocket *, enum cio_websocket_status_code, const char *)
@@ -415,7 +415,7 @@ static void read_handler_save_data(struct cio_websocket *websocket, void *handle
 	}
 }
 
-static void on_control_save_data(const struct cio_websocket *websocket, enum cio_websocket_frame_type type,  const uint8_t *data, size_t length)
+static void on_control_save_data(const struct cio_websocket *websocket, enum cio_websocket_frame_type type,  const uint8_t *data, uint_fast8_t length)
 {
 	(void)websocket;
 	(void)type;

--- a/src/tests/test_cio_websocket.c
+++ b/src/tests/test_cio_websocket.c
@@ -182,8 +182,12 @@ static bool check_frame(enum cio_websocket_frame_type opcode, const char *payloa
 		// TODO unmask_payload
 	}
 
+	if (length > SIZE_MAX) {
+		return false;
+	}
+
 	if (length > 0) {
-		if (memcmp(&write_buffer[write_buffer_parse_pos], payload, length) != 0) {
+		if (memcmp(&write_buffer[write_buffer_parse_pos], payload, (size_t)length) != 0) {
 			return false;
 		}
 	}

--- a/src/tests/test_cio_websocket_client.c
+++ b/src/tests/test_cio_websocket_client.c
@@ -66,8 +66,8 @@ FAKE_VALUE_FUNC(enum cio_error, bs_write, struct cio_buffered_stream *, struct c
 static void on_connect(struct cio_websocket *s);
 FAKE_VOID_FUNC(on_connect, struct cio_websocket *)
 
-static void on_control(const struct cio_websocket *ws, enum cio_websocket_frame_type type, const uint8_t *data, size_t length);
-FAKE_VOID_FUNC(on_control, const struct cio_websocket *, enum cio_websocket_frame_type, const uint8_t *, size_t)
+static void on_control(const struct cio_websocket *ws, enum cio_websocket_frame_type type, const uint8_t *data, uint_fast8_t length);
+FAKE_VOID_FUNC(on_control, const struct cio_websocket *, enum cio_websocket_frame_type, const uint8_t *, uint_fast8_t)
 
 static void on_error(const struct cio_websocket *ws, enum cio_websocket_status_code status, const char *reason);
 FAKE_VOID_FUNC(on_error, const struct cio_websocket *, enum cio_websocket_status_code, const char *)
@@ -327,7 +327,7 @@ static void read_handler_save_data(struct cio_websocket *websocket, void *handle
 	}
 }
 
-static void on_control_save_data(const struct cio_websocket *websocket, enum cio_websocket_frame_type type,  const uint8_t *data, size_t length)
+static void on_control_save_data(const struct cio_websocket *websocket, enum cio_websocket_frame_type type,  const uint8_t *data, uint_fast8_t length)
 {
 	(void)websocket;
 	(void)type;

--- a/src/tests/test_cio_websocket_client.c
+++ b/src/tests/test_cio_websocket_client.c
@@ -144,15 +144,19 @@ static bool check_frame(enum cio_websocket_frame_type opcode, const char *payloa
 		return false;
 	}
 
+	if (length > SIZE_MAX) {
+		return false;
+	}
+
 	if (is_masked) {
 		uint8_t mask[4];
 		memcpy(mask, &write_buffer[write_buffer_parse_pos], sizeof(mask));
 		write_buffer_parse_pos += sizeof(mask);
-		cio_websocket_mask(&write_buffer[write_buffer_parse_pos], length, mask);
+		cio_websocket_mask(&write_buffer[write_buffer_parse_pos], (size_t)length, mask);
 	}
 
 	if (length > 0) {
-		if (memcmp(&write_buffer[write_buffer_parse_pos], payload, length) != 0) {
+		if (memcmp(&write_buffer[write_buffer_parse_pos], payload, (size_t)length) != 0) {
 			return false;
 		}
 	}

--- a/src/tests/test_cio_websocket_location_handler.c
+++ b/src/tests/test_cio_websocket_location_handler.c
@@ -106,8 +106,8 @@ enum cio_error cio_server_socket_init(struct cio_server_socket *ss,
 
 FAKE_VALUE_FUNC(enum cio_error, cio_server_socket_init, struct cio_server_socket *, struct cio_eventloop *, unsigned int, cio_alloc_client, cio_free_client, cio_server_socket_close_hook)
 
-static void on_control(const struct cio_websocket *ws, enum cio_websocket_frame_type type, const uint8_t *data, size_t length);
-FAKE_VOID_FUNC(on_control, const struct cio_websocket *, enum cio_websocket_frame_type, const uint8_t *, size_t)
+static void on_control(const struct cio_websocket *ws, enum cio_websocket_frame_type type, const uint8_t *data, uint_fast8_t length);
+FAKE_VOID_FUNC(on_control, const struct cio_websocket *, enum cio_websocket_frame_type, const uint8_t *, uint_fast8_t)
 
 static void read_handler(struct cio_websocket *ws, void *handler_context, enum cio_error err, uint8_t *data, size_t length, bool last_frame, bool is_binary);
 FAKE_VOID_FUNC(read_handler, struct cio_websocket *, void *, enum cio_error, uint8_t *, size_t, bool, bool)


### PR DESCRIPTION
Also check the length information before processing.