### PR TITLE
fix installation of platform dependant headers

### DIFF
--- a/src/platform/linux/CMakeLists.txt
+++ b/src/platform/linux/CMakeLists.txt
@@ -32,16 +32,16 @@ add_library(PLATFORM OBJECT
 )
 
 set_property(TARGET PLATFORM PROPERTY PUBLIC_HEADER
-    "linux/cio_address_family_impl.h"
-    "linux/cio_error_code_impl.h"
-    "linux/cio_eventloop_impl.h"
-    "linux/cio_inet4_socket_address_impl.h"
-    "linux/cio_inet6_socket_address_impl.h"
-    "linux/cio_inet_address_impl.h"
-    "linux/cio_server_socket_impl.h"
-    "linux/cio_socket_address_impl.h"
-    "linux/cio_socket_impl.h"
-    "linux/cio_timer_impl.h"
+    "platform/linux/cio_address_family_impl.h"
+    "platform/linux/cio_error_code_impl.h"
+    "platform/linux/cio_eventloop_impl.h"
+    "platform/linux/cio_inet4_socket_address_impl.h"
+    "platform/linux/cio_inet6_socket_address_impl.h"
+    "platform/linux/cio_inet_address_impl.h"
+    "platform/linux/cio_server_socket_impl.h"
+    "platform/linux/cio_socket_address_impl.h"
+    "platform/linux/cio_socket_impl.h"
+    "platform/linux/cio_timer_impl.h"
 )
 install(FILES "${CMAKE_CURRENT_LIST_DIR}/cio_unix_address.h"
     DESTINATION include/cio/linux/

--- a/src/platform/windows/CMakeLists.txt
+++ b/src/platform/windows/CMakeLists.txt
@@ -28,11 +28,11 @@ add_library(PLATFORM OBJECT
 
 set_property(TARGET PLATFORM 
     PROPERTY PUBLIC_HEADER
-        "windows/cio_error_code_impl.h"
-        "windows/cio_eventloop_impl.h"
-        "windows/cio_server_socket_impl.h"
-        "windows/cio_socket_impl.h"
-        "windows/cio_timer_impl.h"
+        "platform/windows/cio_error_code_impl.h"
+        "platform/windows/cio_eventloop_impl.h"
+        "platform/windows/cio_server_socket_impl.h"
+        "platform/windows/cio_socket_impl.h"
+        "platform/windows/cio_timer_impl.h"
 )
 
 target_include_directories(PLATFORM


### PR DESCRIPTION
Platform dependant headers moved (see af5ded2ca072e1eba4ae6014b8fdfa0e7fef96d5) but install paths were not adapted accordingly.