### PR TITLE
Take out export declaration.

### DIFF
--- a/lib/src/http_server.c
+++ b/lib/src/http_server.c
@@ -729,7 +729,7 @@ static void server_socket_closed(struct cio_server_socket *ss)
 
 static const unsigned int DEFAULT_BACKLOG = 5;
 
-CIO_EXPORT enum cio_error cio_http_server_init(struct cio_http_server *server,
+enum cio_error cio_http_server_init(struct cio_http_server *server,
                                                struct cio_eventloop *loop,
                                                const struct cio_http_server_configuration *config)
 {


### PR DESCRIPTION
This is only possible in function prototypes.